### PR TITLE
Add interactive editor flow for `quiz add --multiline`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Alternatively, `quiz insert deep-learning/001-logical-gate`.
 
 ````bash
 $ quiz add -m rust/001-macro-count-statements
-Edit the question for rust/001-macro-count-statements, then save and close the editor.
-# $EDITOR opens — type the question body and save:
+Press Enter to edit the question for rust/001-macro-count-statements in vi...
+# press Enter; $EDITOR opens — type the question body and save:
 What is the output of this Rust program?
 
 ```rust
@@ -76,8 +76,8 @@ fn main() {
     );
 }
 ```
-Edit the answer for rust/001-macro-count-statements, then save and close the editor.
-# $EDITOR reopens — type the answer body and save:
+Press Enter to edit the answer for rust/001-macro-count-statements in vi...
+# press Enter; $EDITOR reopens — type the answer body and save:
 112
 ````
 

--- a/README.md
+++ b/README.md
@@ -50,34 +50,35 @@ Alternatively, `quiz insert deep-learning/001-logical-gate`.
 
 ### Add multiline quiz to store
 
-`quiz add -m` opens `$EDITOR` (default `vi`) on a temporary file prefilled with a `question: |` / `answer: |` YAML template, so you can write multi-line questions and answers.
+`quiz add -m` opens `$EDITOR` (default `vi`) twice — first on an empty buffer for the question body, then on an empty buffer for the answer body. The two buffers are assembled into a YAML file with `question: |` and `answer: |` block scalars, so you can author multi-line questions and answers without writing YAML by hand.
 
 ````bash
 $ quiz add -m rust/001-macro-count-statements
-# $EDITOR opens with the following prefilled, edit and save:
-question: |
-  What is the output of this Rust program?
+Edit the question for rust/001-macro-count-statements, then save and close the editor.
+# $EDITOR opens — type the question body and save:
+What is the output of this Rust program?
 
-  ```rust
-  macro_rules! m {
-      ($($s:stmt)*) => {
-          $(
-              { stringify!($s); 1 }
-          )<<*
-      };
-  }
+```rust
+macro_rules! m {
+    ($($s:stmt)*) => {
+        $(
+            { stringify!($s); 1 }
+        )<<*
+    };
+}
 
-  fn main() {
-      print!(
-          "{}{}{}",
-          m! { return || true },
-          m! { (return) || true },
-          m! { {return} || true },
-      );
-  }
-  ```
-answer: |
-  112
+fn main() {
+    print!(
+        "{}{}{}",
+        m! { return || true },
+        m! { (return) || true },
+        m! { {return} || true },
+    );
+}
+```
+Edit the answer for rust/001-macro-count-statements, then save and close the editor.
+# $EDITOR reopens — type the answer body and save:
+112
 ````
 
 ### List existing quizzes in store

--- a/README.md
+++ b/README.md
@@ -50,31 +50,34 @@ Alternatively, `quiz insert deep-learning/001-logical-gate`.
 
 ### Add multiline quiz to store
 
+`quiz add -m` opens `$EDITOR` (default `vi`) on a temporary file prefilled with a `question: |` / `answer: |` YAML template, so you can write multi-line questions and answers.
+
 ````bash
 $ quiz add -m rust/001-macro-count-statements
-Enter quiz of rust/002-bitand-or-reference and press Ctrl+D when finished
+# $EDITOR opens with the following prefilled, edit and save:
+question: |
+  What is the output of this Rust program?
 
-112
-What is the output of this Rust program?
+  ```rust
+  macro_rules! m {
+      ($($s:stmt)*) => {
+          $(
+              { stringify!($s); 1 }
+          )<<*
+      };
+  }
 
-```rust
-macro_rules! m {
-    ($($s:stmt)*) => {
-        $(
-            { stringify!($s); 1 }
-        )<<*
-    };
-}
-
-fn main() {
-    print!(
-        "{}{}{}",
-        m! { return || true },
-        m! { (return) || true },
-        m! { {return} || true },
-    );
-}
-```
+  fn main() {
+      print!(
+          "{}{}{}",
+          m! { return || true },
+          m! { (return) || true },
+          m! { {return} || true },
+      );
+  }
+  ```
+answer: |
+  112
 ````
 
 ### List existing quizzes in store

--- a/man/quiz.1
+++ b/man/quiz.1
@@ -86,10 +86,11 @@ prompts for question and answer on standard input. If \fI--multiline\fP or \fI-m
 is specified, the default text editor specified by the environment variable \fIEDITOR\fP
 or
 .BR vi (1)
-as a fallback is opened on a temporary file prefilled with a \fIquestion: |\fP /
-\fIanswer: |\fP YAML template, allowing multi-line entry. Prompt before overwriting an
-existing quiz, unless \fI--force\fP or \fI-f\fP is specified. This command is
-alternatively named \fBinsert\fP.
+as a fallback is opened twice — first on an empty buffer for the question body,
+then on an empty buffer for the answer body — and the two buffers are assembled
+into a YAML file with \fIquestion: |\fP and \fIanswer: |\fP block scalars. Prompt
+before overwriting an existing quiz, unless \fI--force\fP or \fI-f\fP is specified.
+This command is alternatively named \fBinsert\fP.
 .TP
 \fBedit\fP \fIquiz-name\fP
 Insert a new quiz or edit an existing quiz using the default text editor specified

--- a/man/quiz.1
+++ b/man/quiz.1
@@ -81,11 +81,15 @@ program. This command is alternatively named \fBsearch\fP.
 Decrypt and print a quiz named \fIquiz-name\fP.
 .TP
 \fBadd\fP [ \fI--multiline\fP, \fI-m\fP ] [ \fI--force\fP, \fI-f\fP ] \fIquiz-name\fP
-Insert a new quiz into the quiz store called \fIquiz-name\fP. This will
-read the new quiz from standard in. If \fI--multiline\fP or \fI-m\fP is specified, lines
-will be read until EOF or Ctrl+D is reached. Otherwise, only a single line from standard
-in is read. Prompt before overwriting an existing quiz, unless \fI--force\fP or \fI-f\fP
-is specified. This command is alternatively named \fBinsert\fP.
+Insert a new quiz into the quiz store called \fIquiz-name\fP. By default this
+prompts for question and answer on standard input. If \fI--multiline\fP or \fI-m\fP
+is specified, the default text editor specified by the environment variable \fIEDITOR\fP
+or
+.BR vi (1)
+as a fallback is opened on a temporary file prefilled with a \fIquestion: |\fP /
+\fIanswer: |\fP YAML template, allowing multi-line entry. Prompt before overwriting an
+existing quiz, unless \fI--force\fP or \fI-f\fP is specified. This command is
+alternatively named \fBinsert\fP.
 .TP
 \fBedit\fP \fIquiz-name\fP
 Insert a new quiz or edit an existing quiz using the default text editor specified

--- a/man/quiz.1
+++ b/man/quiz.1
@@ -87,10 +87,12 @@ is specified, the default text editor specified by the environment variable \fIE
 or
 .BR vi (1)
 as a fallback is opened twice — first on an empty buffer for the question body,
-then on an empty buffer for the answer body — and the two buffers are assembled
-into a YAML file with \fIquestion: |\fP and \fIanswer: |\fP block scalars. Prompt
-before overwriting an existing quiz, unless \fI--force\fP or \fI-f\fP is specified.
-This command is alternatively named \fBinsert\fP.
+then on an empty buffer for the answer body. Each invocation is preceded by a
+"Press Enter to edit..." prompt so the editor only launches once you confirm.
+The two buffers are assembled into a YAML file with \fIquestion: |\fP and
+\fIanswer: |\fP block scalars. Prompt before overwriting an existing quiz,
+unless \fI--force\fP or \fI-f\fP is specified. This command is alternatively
+named \fBinsert\fP.
 .TP
 \fBedit\fP \fIquiz-name\fP
 Insert a new quiz or edit an existing quiz using the default text editor specified

--- a/src/quiz-store.sh
+++ b/src/quiz-store.sh
@@ -238,11 +238,13 @@ cmd_insert() {
 		: > "$q_file"
 		: > "$a_file"
 
-		echo "Edit the question for $path, then save and close the editor."
+		echo "Press Enter to edit the question for $path in ${EDITOR:-vi}..."
+		read -r
 		${EDITOR:-vi} "$q_file"
 		[[ -f $q_file ]] || die "New quiz not saved."
 
-		echo "Edit the answer for $path, then save and close the editor."
+		echo "Press Enter to edit the answer for $path in ${EDITOR:-vi}..."
+		read -r
 		${EDITOR:-vi} "$a_file"
 		[[ -f $a_file ]] || die "New quiz not saved."
 

--- a/src/quiz-store.sh
+++ b/src/quiz-store.sh
@@ -134,8 +134,8 @@ cmd_usage() {
 	echo "    $PROGRAM grep [GREPOPTIONS] search-string"
 	echo "        Search for quiz files containing search-string when decrypted."
 	echo "    $PROGRAM insert [--multiline,-m] [--force,-f] quiz-name"
-	echo "        Insert new quiz. Optionally, echo the quiz back to the console"
-	echo "        during entry. Or, optionally, the entry may be multiline. Prompt before"
+	echo "        Insert new quiz. With --multiline, open ${EDITOR:-vi} prefilled with a"
+	echo "        question:/answer: YAML template for multi-line entry. Prompt before"
 	echo "        overwriting existing quiz unless forced."
 	echo "    $PROGRAM edit quiz-name"
 	echo "        Insert a new quiz or edit an existing quiz using ${EDITOR:-vi}."
@@ -230,10 +230,12 @@ cmd_insert() {
 	mkdir -p -v "$PREFIX/$(dirname -- "$path")"
 
 	if [[ $multiline -eq 1 ]]; then
-		echo "Enter quiz of $path and press Ctrl+D when finished:"
-		echo
-		local quiz=$(cat)
-		echo "$quiz" > "$quizfile" || exit 1
+		tmpdir #Defines $SECURE_TMPDIR
+		local tmp_file="$(mktemp -u "$SECURE_TMPDIR/XXXXXX")-${path//\//-}.yml"
+		printf 'question: |\nanswer: |\n' > "$tmp_file"
+		${EDITOR:-vi} "$tmp_file"
+		[[ -f $tmp_file ]] || die "New quiz not saved."
+		mv "$tmp_file" "$quizfile" || exit 1
 	else
 		local quiz question answer
 		read -r -p "Enter question for $path: " -e question

--- a/src/quiz-store.sh
+++ b/src/quiz-store.sh
@@ -134,9 +134,10 @@ cmd_usage() {
 	echo "    $PROGRAM grep [GREPOPTIONS] search-string"
 	echo "        Search for quiz files containing search-string when decrypted."
 	echo "    $PROGRAM insert [--multiline,-m] [--force,-f] quiz-name"
-	echo "        Insert new quiz. With --multiline, open ${EDITOR:-vi} prefilled with a"
-	echo "        question:/answer: YAML template for multi-line entry. Prompt before"
-	echo "        overwriting existing quiz unless forced."
+	echo "        Insert new quiz. With --multiline, open ${EDITOR:-vi} twice — first for"
+	echo "        the question body, then for the answer body — and assemble them into a"
+	echo "        question:/answer: YAML file. Prompt before overwriting existing quiz"
+	echo "        unless forced."
 	echo "    $PROGRAM edit quiz-name"
 	echo "        Insert a new quiz or edit an existing quiz using ${EDITOR:-vi}."
 	echo "    $PROGRAM rm [--recursive,-r] [--force,-f] quiz-name"
@@ -231,11 +232,26 @@ cmd_insert() {
 
 	if [[ $multiline -eq 1 ]]; then
 		tmpdir #Defines $SECURE_TMPDIR
-		local tmp_file="$(mktemp -u "$SECURE_TMPDIR/XXXXXX")-${path//\//-}.yml"
-		printf 'question: |\nanswer: |\n' > "$tmp_file"
-		${EDITOR:-vi} "$tmp_file"
-		[[ -f $tmp_file ]] || die "New quiz not saved."
-		mv "$tmp_file" "$quizfile" || exit 1
+		local tmp_prefix="$(mktemp -u "$SECURE_TMPDIR/XXXXXX")-${path//\//-}"
+		local q_file="$tmp_prefix.question.txt"
+		local a_file="$tmp_prefix.answer.txt"
+		: > "$q_file"
+		: > "$a_file"
+
+		echo "Edit the question for $path, then save and close the editor."
+		${EDITOR:-vi} "$q_file"
+		[[ -f $q_file ]] || die "New quiz not saved."
+
+		echo "Edit the answer for $path, then save and close the editor."
+		${EDITOR:-vi} "$a_file"
+		[[ -f $a_file ]] || die "New quiz not saved."
+
+		{
+			echo "question: |"
+			awk '{print "  " $0}' "$q_file"
+			echo "answer: |"
+			awk '{print "  " $0}' "$a_file"
+		} > "$quizfile" || exit 1
 	else
 		local quiz question answer
 		read -r -p "Enter question for $path: " -e question

--- a/tests/fake-editor-write.sh
+++ b/tests/fake-editor-write.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Fake editor program for testing 'quiz add -m'.
+# Writes content to the given file based on the filename suffix:
+#   *.question.txt → $FAKE_EDITOR_Q (or $FAKE_EDITOR_CONTENT)
+#   *.answer.txt   → $FAKE_EDITOR_A (or $FAKE_EDITOR_CONTENT)
+#   anything else  → $FAKE_EDITOR_CONTENT
+#
+# Arguments: <filename>
+# Returns: 0 on success, 1 on error
+
+if [[ $# -ne 1 ]]; then
+	echo "Usage: $0 <filename>"
+	exit 1
+fi
+
+filename=$1
+case "$filename" in
+	*.question.txt) content="${FAKE_EDITOR_Q-$FAKE_EDITOR_CONTENT}" ;;
+	*.answer.txt)   content="${FAKE_EDITOR_A-$FAKE_EDITOR_CONTENT}" ;;
+	*)              content="$FAKE_EDITOR_CONTENT" ;;
+esac
+
+printf '%s\n' "$content" > "$filename"
+exit 0

--- a/tests/t0020-show-tests.sh
+++ b/tests/t0020-show-tests.sh
@@ -11,8 +11,11 @@ test_expect_success 'Test "show" command' '
 '
 
 test_expect_success 'Test "show" command with spaces' '
-	"$QUIZ" add -m "I am a cred with lots of spaces"<<<"BLAH!!" &&
-	[[ $("$QUIZ" show "I am a cred with lots of spaces") == "BLAH!!" ]]
+	export PATH="$TEST_HOME:$PATH" &&
+	export EDITOR="fake-editor-change-answer.sh" &&
+	export FAKE_EDITOR_ANSWER="BLAH!!" &&
+	"$QUIZ" add -m "I am a cred with lots of spaces" &&
+	[[ $("$QUIZ" show "I am a cred with lots of spaces" | head -1) == "BLAH!!" ]]
 '
 
 test_expect_success 'Test "show" command with unicode' '

--- a/tests/t0020-show-tests.sh
+++ b/tests/t0020-show-tests.sh
@@ -12,10 +12,10 @@ test_expect_success 'Test "show" command' '
 
 test_expect_success 'Test "show" command with spaces' '
 	export PATH="$TEST_HOME:$PATH" &&
-	export EDITOR="fake-editor-change-answer.sh" &&
-	export FAKE_EDITOR_ANSWER="BLAH!!" &&
+	export EDITOR="fake-editor-write.sh" &&
+	export FAKE_EDITOR_CONTENT="BLAH!!" &&
 	"$QUIZ" add -m "I am a cred with lots of spaces" &&
-	[[ $("$QUIZ" show "I am a cred with lots of spaces" | head -1) == "BLAH!!" ]]
+	[[ "$("$QUIZ" show "I am a cred with lots of spaces")" == *"BLAH!!"* ]]
 '
 
 test_expect_success 'Test "show" command with unicode' '

--- a/tests/t0020-show-tests.sh
+++ b/tests/t0020-show-tests.sh
@@ -14,7 +14,7 @@ test_expect_success 'Test "show" command with spaces' '
 	export PATH="$TEST_HOME:$PATH" &&
 	export EDITOR="fake-editor-write.sh" &&
 	export FAKE_EDITOR_CONTENT="BLAH!!" &&
-	"$QUIZ" add -m "I am a cred with lots of spaces" &&
+	printf "\n\n" | "$QUIZ" add -m "I am a cred with lots of spaces" &&
 	[[ "$("$QUIZ" show "I am a cred with lots of spaces")" == *"BLAH!!"* ]]
 '
 

--- a/tests/t0050-mv-tests.sh
+++ b/tests/t0050-mv-tests.sh
@@ -12,7 +12,7 @@ test_expect_success 'Basic move command' '
 	export PATH="$TEST_HOME:$PATH" &&
 	export EDITOR="fake-editor-write.sh" &&
 	export FAKE_EDITOR_CONTENT="$INITIAL_QUIZ" &&
-	"$QUIZ" add -m cred1 &&
+	printf "\n\n" | "$QUIZ" add -m cred1 &&
 	"$QUIZ" mv cred1 cred2 &&
 	[[ -e $QUIZ_STORE_DIR/cred2.yml && ! -e $QUIZ_STORE_DIR/cred1.yml ]]
 '

--- a/tests/t0050-mv-tests.sh
+++ b/tests/t0050-mv-tests.sh
@@ -10,8 +10,8 @@ test_expect_success 'Basic move command' '
 	"$QUIZ" init &&
 	"$QUIZ" git init &&
 	export PATH="$TEST_HOME:$PATH" &&
-	export EDITOR="fake-editor-change-answer.sh" &&
-	export FAKE_EDITOR_ANSWER="$INITIAL_QUIZ" &&
+	export EDITOR="fake-editor-write.sh" &&
+	export FAKE_EDITOR_CONTENT="$INITIAL_QUIZ" &&
 	"$QUIZ" add -m cred1 &&
 	"$QUIZ" mv cred1 cred2 &&
 	[[ -e $QUIZ_STORE_DIR/cred2.yml && ! -e $QUIZ_STORE_DIR/cred1.yml ]]
@@ -44,7 +44,7 @@ test_expect_success 'Multi-directory creation and multi-directory empty removal'
 '
 
 test_expect_success 'Password made it until the end' '
-	[[ $("$QUIZ" show cred | head -1) == "$INITIAL_QUIZ" ]]
+	[[ "$("$QUIZ" show cred)" == *"$INITIAL_QUIZ"* ]]
 '
 
 test_expect_success 'Git is consistent' '

--- a/tests/t0050-mv-tests.sh
+++ b/tests/t0050-mv-tests.sh
@@ -9,7 +9,10 @@ INITIAL_QUIZ="bla bla bla will we make it!!"
 test_expect_success 'Basic move command' '
 	"$QUIZ" init &&
 	"$QUIZ" git init &&
-	"$QUIZ" add -m cred1 <<<"$INITIAL_QUIZ" &&
+	export PATH="$TEST_HOME:$PATH" &&
+	export EDITOR="fake-editor-change-answer.sh" &&
+	export FAKE_EDITOR_ANSWER="$INITIAL_QUIZ" &&
+	"$QUIZ" add -m cred1 &&
 	"$QUIZ" mv cred1 cred2 &&
 	[[ -e $QUIZ_STORE_DIR/cred2.yml && ! -e $QUIZ_STORE_DIR/cred1.yml ]]
 '
@@ -41,7 +44,7 @@ test_expect_success 'Multi-directory creation and multi-directory empty removal'
 '
 
 test_expect_success 'Password made it until the end' '
-	[[ $("$QUIZ" show cred) == "$INITIAL_QUIZ" ]]
+	[[ $("$QUIZ" show cred | head -1) == "$INITIAL_QUIZ" ]]
 '
 
 test_expect_success 'Git is consistent' '

--- a/tests/t0100-add-tests.sh
+++ b/tests/t0100-add-tests.sh
@@ -4,15 +4,16 @@ test_description='Test add'
 cd "$(dirname "$0")"
 . ./setup.sh
 
-test_expect_success 'Test "add -m" opens editor with prefilled YAML template' '
+test_expect_success 'Test "add -m" assembles YAML from question and answer editors' '
 	"$QUIZ" init &&
 	export PATH="$TEST_HOME:$PATH" &&
-	export EDITOR="fake-editor-change-answer.sh" &&
-	export FAKE_EDITOR_ANSWER="question: hello" &&
+	export EDITOR="fake-editor-write.sh" &&
+	export FAKE_EDITOR_Q="my question" &&
+	export FAKE_EDITOR_A="my answer" &&
 	"$QUIZ" add -m cred1 &&
 	output="$("$QUIZ" show cred1)" &&
-	[[ "$output" == *"question: hello"* ]] &&
-	[[ "$output" == *"answer: |"* ]]
+	[[ "$output" == *"question: |"*"  my question"* ]] &&
+	[[ "$output" == *"answer: |"*"  my answer"* ]]
 '
 
 test_done

--- a/tests/t0100-add-tests.sh
+++ b/tests/t0100-add-tests.sh
@@ -4,10 +4,15 @@ test_description='Test add'
 cd "$(dirname "$0")"
 . ./setup.sh
 
-test_expect_success 'Test "add" command' '
+test_expect_success 'Test "add -m" opens editor with prefilled YAML template' '
 	"$QUIZ" init &&
-	echo "Hello world" | "$QUIZ" add -m cred1 &&
-	[[ $("$QUIZ" show cred1) == "Hello world" ]]
+	export PATH="$TEST_HOME:$PATH" &&
+	export EDITOR="fake-editor-change-answer.sh" &&
+	export FAKE_EDITOR_ANSWER="question: hello" &&
+	"$QUIZ" add -m cred1 &&
+	output="$("$QUIZ" show cred1)" &&
+	[[ "$output" == *"question: hello"* ]] &&
+	[[ "$output" == *"answer: |"* ]]
 '
 
 test_done

--- a/tests/t0100-add-tests.sh
+++ b/tests/t0100-add-tests.sh
@@ -10,7 +10,7 @@ test_expect_success 'Test "add -m" assembles YAML from question and answer edito
 	export EDITOR="fake-editor-write.sh" &&
 	export FAKE_EDITOR_Q="my question" &&
 	export FAKE_EDITOR_A="my answer" &&
-	"$QUIZ" add -m cred1 &&
+	printf "\n\n" | "$QUIZ" add -m cred1 &&
 	output="$("$QUIZ" show cred1)" &&
 	[[ "$output" == *"question: |"*"  my question"* ]] &&
 	[[ "$output" == *"answer: |"*"  my answer"* ]]

--- a/tests/t0200-edit-tests.sh
+++ b/tests/t0200-edit-tests.sh
@@ -9,7 +9,7 @@ test_expect_success 'Test "edit" command' '
 	export PATH="$TEST_HOME:$PATH" &&
 	export EDITOR="fake-editor-write.sh" &&
 	export FAKE_EDITOR_CONTENT="seed" &&
-	"$QUIZ" add -m cred1 &&
+	printf "\n\n" | "$QUIZ" add -m cred1 &&
 	export EDITOR="fake-editor-change-answer.sh" &&
 	export FAKE_EDITOR_ANSWER="big fat fake quiz" &&
 	"$QUIZ" edit cred1 &&

--- a/tests/t0200-edit-tests.sh
+++ b/tests/t0200-edit-tests.sh
@@ -6,12 +6,13 @@ cd "$(dirname "$0")"
 
 test_expect_success 'Test "edit" command' '
 	"$QUIZ" init &&
-	"$QUIZ" add -m cred1 <<<"$($TEST_HOME/fake-answer.sh 90)" &&
-	export FAKE_EDITOR_ANSWER="big fat fake quiz" &&
-	export PATH="$TEST_HOME:$PATH"
+	export PATH="$TEST_HOME:$PATH" &&
 	export EDITOR="fake-editor-change-answer.sh" &&
+	export FAKE_EDITOR_ANSWER="seed quiz" &&
+	"$QUIZ" add -m cred1 &&
+	export FAKE_EDITOR_ANSWER="big fat fake quiz" &&
 	"$QUIZ" edit cred1 &&
-	[[ $("$QUIZ" show cred1) == "$FAKE_EDITOR_ANSWER" ]]
+	[[ $("$QUIZ" show cred1 | head -1) == "$FAKE_EDITOR_ANSWER" ]]
 '
 
 test_done

--- a/tests/t0200-edit-tests.sh
+++ b/tests/t0200-edit-tests.sh
@@ -7,9 +7,10 @@ cd "$(dirname "$0")"
 test_expect_success 'Test "edit" command' '
 	"$QUIZ" init &&
 	export PATH="$TEST_HOME:$PATH" &&
-	export EDITOR="fake-editor-change-answer.sh" &&
-	export FAKE_EDITOR_ANSWER="seed quiz" &&
+	export EDITOR="fake-editor-write.sh" &&
+	export FAKE_EDITOR_CONTENT="seed" &&
 	"$QUIZ" add -m cred1 &&
+	export EDITOR="fake-editor-change-answer.sh" &&
 	export FAKE_EDITOR_ANSWER="big fat fake quiz" &&
 	"$QUIZ" edit cred1 &&
 	[[ $("$QUIZ" show cred1 | head -1) == "$FAKE_EDITOR_ANSWER" ]]


### PR DESCRIPTION
## Summary
- `quiz add -m <name>` now opens `$EDITOR` (default `vi`) twice — first on an empty buffer for the question body, then on an empty buffer for the answer body — and assembles the two buffers into a YAML file with `question: |` / `answer: |` block scalars, so users no longer hand-edit YAML or rely on stdin piping.
- Each editor invocation is gated by a `Press Enter to edit ... in <editor>...` prompt, so the editor only takes over the terminal once the user confirms.
- Adds `tests/fake-editor-write.sh` (writes `$FAKE_EDITOR_Q` / `$FAKE_EDITOR_A` based on filename suffix, falling back to `$FAKE_EDITOR_CONTENT`) and updates the existing `add -m` callers in the Sharness suite to drive the new flow. `man/quiz.1` and `README.md` are updated to describe the new behavior.

## Test plan
- [x] `make test` — full Sharness suite passes locally
- [x] `npx editorconfig-checker` — CI lint passes
- [x] Manual smoke test: `quiz add -m math/easy` with multi-line question/answer produces well-formed YAML that round-trips through `yaml.safe_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)