### PR TITLE
Fix CI: bump Node, consolidate runners, dedupe triggers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Run a install script
         run: PREFIX=$(brew --prefix) make install
       - name: Prepare dependencies
-        run: brew install tree gnu-sed
+        run: brew install tree gnu-sed gnu-getopt
       - name: Run a test script
         run: make test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,7 @@ jobs:
       - name: Run a test script
         run: make test
   macos:
-    strategy:
-      matrix:
-        os: [macos-12, macos-11]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Run a install script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,7 @@ jobs:
           node-version: 20
       - run: npx editorconfig-checker
   ubuntu:
-    strategy:
-      matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Run a install script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
       - run: npx editorconfig-checker
   ubuntu:
     strategy:

--- a/src/platform/darwin.sh
+++ b/src/platform/darwin.sh
@@ -3,18 +3,11 @@
 
 tmpdir() {
 	[[ -n $SECURE_TMPDIR ]] && return
-	unmount_tmpdir() {
-		[[ -n $SECURE_TMPDIR && -d $SECURE_TMPDIR && -n $DARWIN_RAMDISK_DEV ]] || return
-		umount "$SECURE_TMPDIR"
-		diskutil quiet eject "$DARWIN_RAMDISK_DEV"
+	SECURE_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/$PROGRAM.XXXXXXXXXXXXX")"
+	remove_tmpfile() {
 		rm -rf "$SECURE_TMPDIR"
 	}
-	trap unmount_tmpdir INT TERM EXIT
-	SECURE_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/$PROGRAM.XXXXXXXXXXXXX")"
-	DARWIN_RAMDISK_DEV="$(hdid -drivekey system-image=yes -nomount 'ram://32768' | cut -d ' ' -f 1)" # 32768 sectors = 16 mb
-	[[ -z $DARWIN_RAMDISK_DEV ]] && die "Error: could not create ramdisk."
-	newfs_hfs -M 700 "$DARWIN_RAMDISK_DEV" &>/dev/null || die "Error: could not create filesystem on ramdisk."
-	mount -t hfs -o noatime -o nobrowse "$DARWIN_RAMDISK_DEV" "$SECURE_TMPDIR" || die "Error: could not mount filesystem on ramdisk."
+	trap remove_tmpfile EXIT
 }
 
 GETOPT="$({ test -x /usr/local/opt/gnu-getopt/bin/getopt && echo /usr/local/opt/gnu-getopt; } || brew --prefix gnu-getopt 2>/dev/null || { command -v port &>/dev/null && echo /opt/local; } || echo /usr/local)/bin/getopt"


### PR DESCRIPTION
## Summary
- **lint**: Bump `actions/setup-node` from Node.js 16 → 20. `editorconfig-checker@6.1.1` requires Node.js ≥ 20.11.0, so the lint job was crashing with `TypeError [ERR_INVALID_ARG_TYPE]` on Node 16.
- **macos**: Drop the `macos-12` / `macos-11` matrix and run on `macos-latest` only. Both `macos-11` (EOL 2024-06) and `macos-12` (EOL 2024-12) are no longer available as GitHub-hosted runners. macOS-specific behavior lives in `src/platform/darwin.sh` and is mediated by Homebrew's `gnu-sed` / `gnu-getopt`, which doesn't vary by macOS version.
- **ubuntu**: Drop the `ubuntu-22.04` / `ubuntu-20.04` matrix and run on `ubuntu-latest` only. `ubuntu-20.04` reached EOL on GitHub-hosted runners in 2025-04. The project's Linux dependencies (coreutils, git, tree) don't vary across Ubuntu versions.
- **triggers**: Restrict `on: push` to `master` only. Previously `push` had no branches filter, so any push to a branch with an open PR fired both the `push` and `pull_request` events and ran the workflow twice in parallel.
- **darwin tmpdir**: Drop the HFS ramdisk shredding from `src/platform/darwin.sh`. That logic was inherited from `pass` (a password manager) so secrets in tempfiles could never reach disk. `quiz` stores flashcards, not secrets, and on modern macOS (Apple Silicon, macOS 14/15) the `hdid` / `newfs_hfs` / `mount -t hfs` calls hung `make test` indefinitely. Replace with the same `mktemp -d` + `rm -rf`-on-EXIT pattern the Linux `/dev/shm` branch uses.
- **macOS deps**: Add `gnu-getopt` to the `brew install` step. `darwin.sh` resolves `$GETOPT` via `brew --prefix gnu-getopt`, which echoes the expected install path even when the formula isn't installed, so `$GETOPT` was pointing at a non-existent binary and `make test` failed with `No such file or directory`.

## Test plan
- [ ] `lint` job passes on this PR
- [ ] `macos (macos-latest)` job runs to completion (no hang, getopt resolves) and passes
- [ ] `ubuntu (ubuntu-latest)` job runs and passes
- [ ] Only one workflow run is created per push to this PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)